### PR TITLE
Update user guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Ansible is an open source toolkit, written in Python, it is used for  Configurat
 > Official Resources by and for Ansible.
 
 - [Ansible Site](https://www.ansible.com/) - Ansible Company Site
-- [Latest Ansible Documentation](https://docs.ansible.com/ansible/latest/intro.html) - Official latest Documentation for Ansible
+- [Latest Ansible Documentation](https://docs.ansible.com/ansible/latest/user_guide/index.html) - Latest user guide and documentation for Ansible
 - [Ansible Galaxy Website](https://galaxy.ansible.com/) - Official Repository and community site for Ansible Roles.
 - [Ansible Blog](https://www.ansible.com/blog) - Official Ansible Blog
 


### PR DESCRIPTION
intro.html is still a part of the source code (`ansible/docs/docsite/rst/user_guide/intro.rst`), but not linked in any TOC – therefore prefer index.html. Also, clarify that the link points to the user guide, not to the documentation root page (this is fine IMO).